### PR TITLE
Utilize mimalloc

### DIFF
--- a/simple_live_app/linux/CMakeLists.txt
+++ b/simple_live_app/linux/CMakeLists.txt
@@ -91,6 +91,7 @@ set_target_properties(${BINARY_NAME}
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
 
 # === Installation ===
 # By default, "installing" just makes a relocatable bundle in the build


### PR DESCRIPTION
You should consider replacing the default memory allocator with mimalloc for [avoiding memory leaks.](https://github.com/media-kit/media-kit/issues/68)

This is as simple as [adding one line to linux/CMakeLists.txt:](https://github.com/media-kit/media-kit/blob/d02a97ce70b316207db024401fb99e3f4509a250/media_kit_test/linux/CMakeLists.txt#L92-L94)
`
target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})`