### PR TITLE
修复虎牙播放中断问题

### DIFF
--- a/simple_live_core/lib/src/huya_site.dart
+++ b/simple_live_core/lib/src/huya_site.dart
@@ -465,7 +465,7 @@ class HuyaSite implements LiveSite {
     // 通过ChatGPT转换的Dart代码
     var query = Uri.splitQueryString(anticode);
 
-    query["t"] = "100";
+    query["t"] = "102";
     query["ctype"] = "huya_live";
 
     final wsTime = (DateTime.now().millisecondsSinceEpoch ~/ 1000 + 21600)


### PR DESCRIPTION
参数t="100"失效 改为“102” 这个参数很久之前就改为102了