### PR TITLE
修复虎牙一起看分区两分钟时参数验证失败

### DIFF
--- a/simple_live_core/lib/src/huya_site.dart
+++ b/simple_live_core/lib/src/huya_site.dart
@@ -466,7 +466,7 @@ class HuyaSite implements LiveSite {
     var query = Uri.splitQueryString(anticode);
 
     query["t"] = "102";
-    query["ctype"] = "huya_live";
+    query["ctype"] = "tars_mp";
 
     final wsTime = (DateTime.now().millisecondsSinceEpoch ~/ 1000 + 21600)
         .toRadixString(16);


### PR DESCRIPTION
ctype = huya_live  虎牙只有一起看分区现在会在两分钟时参数验证失败， 上午还没问题，改为 tars_mp 可以修复。