### PR TITLE
Remove the greenish yellow focus border Fixes. #612

### DIFF
--- a/simple_live_tv_app/android/app/src/main/res/values-night/styles.xml
+++ b/simple_live_tv_app/android/app/src/main/res/values-night/styles.xml
@@ -5,6 +5,8 @@
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
+        <!-- Disable the greenish yellow focus border that shows up when using physical or emulated peripherals -->
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -14,6 +16,8 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <!-- Disable the greenish yellow focus border that shows up when using physical or emulated peripherals -->
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
 
     <!-- 自定义dialog样式 -->

--- a/simple_live_tv_app/android/app/src/main/res/values/styles.xml
+++ b/simple_live_tv_app/android/app/src/main/res/values/styles.xml
@@ -5,6 +5,8 @@
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
+        <!-- Disable the greenish yellow focus border that shows up when using physical or emulated peripherals -->
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -14,6 +16,8 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <!-- Disable the greenish yellow focus border that shows up when using physical or emulated peripherals -->
+        <item name="android:defaultFocusHighlightEnabled">false</item>
     </style>
 
     <style name="MainTheme" parent="Theme.AppCompat.Light.NoActionBar">


### PR DESCRIPTION
The border that shows up by default is meant for indicating the window being focused when using a physical or emulated peripheral. For a TV app that supposedly runs exclusively in full screen, it makes sense to disable this distractive border by setting `defaultFocusHighlightEnabled` to `false`. 