### PR TITLE
仅在 Android/iOS/macOS 平台显示手势提示：#695

### DIFF
--- a/simple_live_app/lib/modules/live_room/player/player_controller.dart
+++ b/simple_live_app/lib/modules/live_room/player/player_controller.dart
@@ -525,7 +525,9 @@ mixin PlayerGestureControlMixin
     throttle = DelayedThrottle(200);
 
     verticalDragging = true;
-    showGestureTip.value = true;
+    if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
+      showGestureTip.value = true;
+    }
     if (Platform.isAndroid || Platform.isIOS) {
       _currentVolume = await volumeController.getVolume();
     }


### PR DESCRIPTION
修复问题：#695 台式电脑不支持手势音量和亮度调节