### PR TITLE
修复一些标签功能的问题

### DIFF
--- a/simple_live_app/lib/modules/follow_user/follow_user_controller.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_user_controller.dart
@@ -131,7 +131,7 @@ class FollowUserController extends BasePageController<FollowUser> {
     filterData();
   }
 
-  void removeTag(FollowUserTag tag) {
+  Future<void> removeTag(FollowUserTag tag) async {
     // 将tag下的所有follow设置为全部
     for(var i in tag.userId){
       var follow = DBService.instance.followBox.get(i);
@@ -140,7 +140,7 @@ class FollowUserController extends BasePageController<FollowUser> {
         updateItem(follow);
       }
     }
-    FollowService.instance.delFollowUserTag(tag);
+    await FollowService.instance.delFollowUserTag(tag);
     updateTagList();
     Log.i('删除tag${tag.tag}');
   }
@@ -158,19 +158,27 @@ class FollowUserController extends BasePageController<FollowUser> {
     FollowService.instance.updateFollowUserTag(followUserTag);
   }
 
-  void updateTagName(FollowUserTag followUserTag, String tag) {
+  void updateTagName(FollowUserTag followUserTag, String newTagName) {
     // 未操作
-    if (followUserTag.tag == tag) {
+    if (followUserTag.tag == newTagName) {
       return;
     }
     // 避免重名
-    if (tagList.any((item) => item.tag == tag)) {
+    if (tagList.any((item) => item.tag == newTagName)) {
       SmartDialog.showToast("标签名重复，修改失败");
       return;
     }
-    final FollowUserTag item = followUserTag.copyWith(tag: tag);
-    updateTag(item);
-    SmartDialog.showToast("修改成功");
+    final FollowUserTag newTag = followUserTag.copyWith(tag: newTagName);
+    updateTag(newTag);
+    // update item's tag when update tagName
+    for(var i in newTag.userId){
+      var follow = DBService.instance.followBox.get(i);
+      if(follow != null){
+        follow.tag = newTagName;
+        updateItem(follow);
+      }
+    }
+    SmartDialog.showToast("标签名修改成功");
     updateTagList();
   }
 

--- a/simple_live_app/lib/modules/follow_user/follow_user_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_user_page.dart
@@ -211,7 +211,6 @@ class FollowUserPage extends GetView<FollowUserController> {
                 IconButton(
                   icon: const Icon(
                     Icons.check,
-                    color: Colors.black,
                   ),
                   onPressed: () {
                     controller.setItemTag(item, checkTag.value);

--- a/simple_live_app/lib/modules/live_room/live_room_controller.dart
+++ b/simple_live_app/lib/modules/live_room/live_room_controller.dart
@@ -317,6 +317,8 @@ class LiveRoomController extends PlayerController with WidgetsBindingObserver {
       getSuperChatMessage();
 
       addHistory();
+      // 确认房间关注状态
+      followed.value = DBService.instance.getFollowExist("${site.id}_$roomId");
       online.value = detail.value!.online;
       liveStatus.value = detail.value!.status || detail.value!.isRecord;
       if (liveStatus.value) {

--- a/simple_live_app/lib/modules/sync/remote_sync/webdav/remote_sync_webdav_controller.dart
+++ b/simple_live_app/lib/modules/sync/remote_sync/webdav/remote_sync_webdav_controller.dart
@@ -261,7 +261,6 @@ class RemoteSyncWebDAVController extends BaseController {
             var user = FollowUser.fromJson(item);
             await DBService.instance.followBox.put(user.id, user);
           }
-          EventBus.instance.emit(Constant.kUpdateFollow, 0);
           Log.i('已同步关注用户列表');
         } catch (e) {
           Log.e('同步关注用户列表失败: $e', StackTrace.current);

--- a/simple_live_app/lib/services/follow_service.dart
+++ b/simple_live_app/lib/services/follow_service.dart
@@ -68,9 +68,9 @@ class FollowService extends GetxService {
   }
 
   // 删除标签
-  void delFollowUserTag(FollowUserTag tag) {
+  Future<void> delFollowUserTag(FollowUserTag tag) async {
     followTagList.remove(tag);
-    DBService.instance.deleteFollowTag(tag.id);
+    await DBService.instance.deleteFollowTag(tag.id);
   }
 
   // 获取用户自定义标签列表


### PR DESCRIPTION
### 如下修改
- 右上角的确认按钮主题颜色适配问题
- 在修改标签名字时，缺少删除同步导致的数据混乱
- webdav 在同步关注和标签重复刷新问题
- 进入未关注房间，切换关注列表关注项时左下角关注显示不同步切换