### PR TITLE
fix: 修复 Android 保存文件崩溃

### DIFF
--- a/simple_live_app/lib/modules/settings/other/other_settings_controller.dart
+++ b/simple_live_app/lib/modules/settings/other/other_settings_controller.dart
@@ -142,6 +142,7 @@ class OtherSettingsController extends BaseController {
       allowedExtensions: ['log'],
       type: FileType.custom,
       fileName: item.name,
+      bytes: Uint8List(0),
     );
     if (filePath != null) {
       var file = File(item.path);


### PR DESCRIPTION
在高版本安卓系统中，file_picker 的 saveFile 方法存在崩溃问题。

该问题已在 file_picker 的 [8.3.4 版本](https://github.com/miguelpruivo/flutter_file_picker/releases/tag/8.3.4)中修复。由于当前 simple_live 使用的 file_picker 版本为 8.0.3，相对较低，因此本次修复仅在保存文件时避免传入 null byte array，以临时规避该问题。

相关修复可参考：[PR #1662](https://github.com/miguelpruivo/flutter_file_picker/pull/1662)