### PR TITLE
使用 Playlist 实现多线路功能

### DIFF
--- a/simple_live_app/lib/modules/live_room/live_room_controller.dart
+++ b/simple_live_app/lib/modules/live_room/live_room_controller.dart
@@ -406,7 +406,7 @@ class LiveRoomController extends PlayerController with WidgetsBindingObserver {
     currentLineInfo.value = "线路${currentLineIndex + 1}";
     //重置错误次数
     mediaErrorRetryCount = 0;
-    setPlayer();
+    initPlaylist();
   }
 
   void changePlayLine(int index) {
@@ -416,25 +416,33 @@ class LiveRoomController extends PlayerController with WidgetsBindingObserver {
     setPlayer();
   }
 
-  void setPlayer() async {
+  void initPlaylist() async {
     currentLineInfo.value = "线路${currentLineIndex + 1}";
     errorMsg.value = "";
 
-    var playurl = playUrls[currentLineIndex];
-    if (AppSettingsController.instance.playerForceHttps.value) {
-      playurl = playurl.replaceAll("http://", "https://");
-    }
+    final mediaList = playUrls.map((url) {
+      var finalUrl = url;
+      if (AppSettingsController.instance.playerForceHttps.value) {
+        finalUrl = finalUrl.replaceAll("http://", "https://");
+      }
+      return Media(finalUrl, httpHeaders: playHeaders);
+    }).toList();
 
     // 初始化播放器并设置 ao 参数
     await initializePlayer();
 
     await player.open(
-      Media(
-        playurl,
-        httpHeaders: playHeaders,
-      ),
+      Playlist(
+        mediaList
+      )
     );
-    Log.d("播放链接\r\n：$playurl");
+  }
+
+  void setPlayer() async {
+    currentLineInfo.value = "线路${currentLineIndex + 1}";
+    errorMsg.value = "";
+
+    await player.jump(currentLineIndex);
   }
 
   @override


### PR DESCRIPTION
在 Linux 平台下使用 simple_live 时，切换线路后会出现播放器有声音但无画面的问题，该问题在 Android 平台上不存在。

经测试，将所有线路作为播放列表（playlist）传入 mediakit 播放器可解决此问题。切换线路时，只需切换到播放列表中对应的播放链接即可。