### PR TITLE
App切换或者直播间刷新之后尝试恢复弹幕

### DIFF
--- a/simple_live_app/lib/modules/live_room/live_room_controller.dart
+++ b/simple_live_app/lib/modules/live_room/live_room_controller.dart
@@ -991,6 +991,9 @@ class LiveRoomController extends PlayerController with WidgetsBindingObserver {
 
     // 刷新信息
     loadData();
+
+    // 恢复弹幕
+    danmakuController?.resume();
   }
 
   void copyErrorDetail() {
@@ -1016,6 +1019,8 @@ ${error?.stackTrace}''');
     //返回前台
     if (state == AppLifecycleState.resumed) {
       Log.d("返回前台");
+      // 恢复弹幕
+      danmakuController?.resume();
       isBackground = false;
     }
   }

--- a/simple_live_tv_app/lib/modules/live_room/live_room_controller.dart
+++ b/simple_live_tv_app/lib/modules/live_room/live_room_controller.dart
@@ -372,6 +372,9 @@ class LiveRoomController extends PlayerController with WidgetsBindingObserver {
 
     // 刷新信息
     loadData();
+
+    // 恢复弹幕
+    danmakuController?.resume();
   }
 
   void nextChannel() {
@@ -433,6 +436,8 @@ class LiveRoomController extends PlayerController with WidgetsBindingObserver {
     //返回前台
     if (state == AppLifecycleState.resumed) {
       Log.d("返回前台");
+      // 恢复弹幕
+      danmakuController?.resume();
       isBackground = false;
     }
   }


### PR DESCRIPTION
在 iPadOS 上，该 app 在恢复前台/直播间刷新之后弹幕会消失。

该 PR 尝试解决这个问题，只在 iPadOS 26.3 上测试成功，猜测其它平台效果类似。