### PR TITLE
feat: shared TabController between HomePage and CategoryPage

### DIFF
--- a/simple_live_app/lib/modules/category/category_controller.dart
+++ b/simple_live_app/lib/modules/category/category_controller.dart
@@ -7,14 +7,11 @@ import 'package:simple_live_app/app/controller/base_controller.dart';
 import 'package:simple_live_app/app/event_bus.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/modules/category/category_list_controller.dart';
+import 'package:simple_live_app/modules/indexed/indexed_controller.dart';
 
-class CategoryController extends GetxController
-    with GetSingleTickerProviderStateMixin {
-  late TabController tabController;
-  CategoryController() {
-    tabController =
-        TabController(length: Sites.supportSites.length, vsync: this);
-  }
+class CategoryController extends GetxController {
+  TabController get tabController =>
+      Get.find<IndexedController>().tabController;
   StreamSubscription<dynamic>? streamSubscription;
   @override
   void onInit() {

--- a/simple_live_app/lib/modules/home/home_controller.dart
+++ b/simple_live_app/lib/modules/home/home_controller.dart
@@ -7,15 +7,12 @@ import 'package:simple_live_app/app/controller/base_controller.dart';
 import 'package:simple_live_app/app/event_bus.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/modules/home/home_list_controller.dart';
+import 'package:simple_live_app/modules/indexed/indexed_controller.dart';
 import 'package:simple_live_app/routes/route_path.dart';
 
-class HomeController extends GetxController
-    with GetSingleTickerProviderStateMixin {
-  late TabController tabController;
-  HomeController() {
-    tabController =
-        TabController(length: Sites.supportSites.length, vsync: this);
-  }
+class HomeController extends GetxController {
+  TabController get tabController =>
+      Get.find<IndexedController>().tabController;
 
   StreamSubscription<dynamic>? streamSubscription;
 

--- a/simple_live_app/lib/modules/indexed/indexed_controller.dart
+++ b/simple_live_app/lib/modules/indexed/indexed_controller.dart
@@ -1,9 +1,10 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 import 'package:get/get.dart';
 import 'package:simple_live_app/app/constant.dart';
 import 'package:simple_live_app/app/controller/app_settings_controller.dart';
 import 'package:simple_live_app/app/event_bus.dart';
+import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/category/category_controller.dart';
 import 'package:simple_live_app/modules/category/category_page.dart';
@@ -13,10 +14,13 @@ import 'package:simple_live_app/modules/follow_user/follow_user_controller.dart'
 import 'package:simple_live_app/modules/follow_user/follow_user_page.dart';
 import 'package:simple_live_app/modules/mine/mine_page.dart';
 
-class IndexedController extends GetxController {
+class IndexedController extends GetxController
+    with GetSingleTickerProviderStateMixin {
   RxList<HomePageItem> items = RxList<HomePageItem>([]);
 
   var index = 0.obs;
+
+  late TabController tabController;
   RxList<Widget> pages = RxList<Widget>([
     const SizedBox(),
     const SizedBox(),
@@ -56,6 +60,8 @@ class IndexedController extends GetxController {
 
   @override
   void onInit() {
+    tabController =
+        TabController(length: Sites.supportSites.length, vsync: this);
     Future.delayed(Duration.zero, showFirstRun);
     items.value = AppSettingsController.instance.homeSort
         .map((key) => Constant.allHomePages[key]!)
@@ -64,11 +70,17 @@ class IndexedController extends GetxController {
     super.onInit();
   }
 
+  @override
+  void onClose() {
+    tabController.dispose();
+    super.onClose();
+  }
+
   void showFirstRun() async {
     var settingsController = Get.find<AppSettingsController>();
     if (settingsController.firstRun) {
       settingsController.setNoFirstRun();
       await Utils.showStatement();
-    } 
+    }
   }
 }


### PR DESCRIPTION
当前主页，直播类型页面均有4个直播平台的 tab 子页面。
但是它们是各自独立的，比如我在主页选择了“虎牙”，一般来说我希望我点击直播分类页面的时候，打开的也是“虎牙”的分类页面，然而现在的逻辑会跳转到排序最靠前的平台。

该 PR 代码为 gemini 生成，经我有限的 flutter 知识判断，逻辑正确。同时 app 测试功能正常 (iPadOS macOS).