### PR TITLE
feat: 在播放页面长按弹窗中添加观看历史切换功能

### DIFF
--- a/simple_live_app/lib/modules/live_room/live_room_controller.dart
+++ b/simple_live_app/lib/modules/live_room/live_room_controller.dart
@@ -24,6 +24,7 @@ import 'package:simple_live_app/services/db_service.dart';
 import 'package:simple_live_app/services/follow_service.dart';
 import 'package:simple_live_app/widgets/desktop_refresh_button.dart';
 import 'package:simple_live_app/widgets/follow_user_item.dart';
+import 'package:simple_live_app/widgets/net_image.dart';
 import 'package:simple_live_core/simple_live_core.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
@@ -106,6 +107,9 @@ class LiveRoomController extends PlayerController with WidgetsBindingObserver {
   // 开播时长状态变量
   var liveDuration = "00:00:00".obs;
   Timer? _liveDurationTimer;
+
+  /// 关注/历史列表切换状态 (true: 关注列表, false: 观看历史)
+  var showFollowList = true.obs;
 
   @override
   void onInit() {
@@ -827,48 +831,140 @@ class LiveRoomController extends PlayerController with WidgetsBindingObserver {
   }
 
   void showFollowUserSheet() {
+    // 不重置状态,保持上次选择的列表
     Utils.showBottomSheet(
-      title: "关注列表",
-      child: Obx(
-        () => Stack(
+      title: "",
+      child: DefaultTabController(
+        length: 2,
+        initialIndex: showFollowList.value ? 0 : 1,
+        child: Column(
           children: [
-            RefreshIndicator(
-              onRefresh: FollowService.instance.loadData,
-              child: ListView.builder(
-                itemCount: FollowService.instance.liveList.length,
-                itemBuilder: (_, i) {
-                  var item = FollowService.instance.liveList[i];
-                  return Obx(
-                    () => FollowUserItem(
-                      item: item,
-                      playing: rxSite.value.id == item.siteId &&
-                          rxRoomId.value == item.roomId,
-                      onTap: () {
-                        Get.back();
-                        resetRoom(
-                          Sites.allSites[item.siteId]!,
-                          item.roomId,
-                        );
-                      },
-                    ),
-                  );
-                },
+            TabBar(
+              indicatorSize: TabBarIndicatorSize.tab,
+              labelPadding: EdgeInsets.zero,
+              indicatorWeight: 1.0,
+              onTap: (index) {
+                showFollowList.value = index == 0;
+              },
+              tabs: const [
+                Tab(text: "关注列表"),
+                Tab(text: "观看历史"),
+              ],
+            ),
+            Expanded(
+              child: TabBarView(
+                children: [
+                  _buildFollowListView(),
+                  _buildHistoryListView(),
+                ],
               ),
             ),
-            if (Platform.isLinux || Platform.isWindows || Platform.isMacOS)
-              Positioned(
-                right: 12,
-                bottom: 12,
-                child: Obx(
-                  () => DesktopRefreshButton(
-                    refreshing: FollowService.instance.updating.value,
-                    onPressed: FollowService.instance.loadData,
-                  ),
-                ),
-              ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildFollowListView() {
+    return Obx(
+      () => Stack(
+        children: [
+          RefreshIndicator(
+            onRefresh: FollowService.instance.loadData,
+            child: ListView.builder(
+              itemCount: FollowService.instance.liveList.length,
+              itemBuilder: (_, i) {
+                var item = FollowService.instance.liveList[i];
+                return Obx(
+                  () => FollowUserItem(
+                    item: item,
+                    playing: rxSite.value.id == item.siteId &&
+                        rxRoomId.value == item.roomId,
+                    onTap: () {
+                      Get.back();
+                      resetRoom(
+                        Sites.allSites[item.siteId]!,
+                        item.roomId,
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+          if (Platform.isLinux || Platform.isWindows || Platform.isMacOS)
+            Positioned(
+              right: 12,
+              bottom: 12,
+              child: Obx(
+                () => DesktopRefreshButton(
+                  refreshing: FollowService.instance.updating.value,
+                  onPressed: FollowService.instance.loadData,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHistoryListView() {
+    var historyList = DBService.instance.getHistores();
+    return ListView.builder(
+      itemCount: historyList.length,
+      itemBuilder: (_, i) {
+        var item = historyList[i];
+        var itemSite = Sites.allSites[item.siteId];
+        if (itemSite == null) return const SizedBox.shrink();
+        
+        return ListTile(
+          contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 4),
+          leading: NetImage(
+            item.face,
+            width: 48,
+            height: 48,
+            borderRadius: 24,
+          ),
+          title: Text(item.userName),
+          subtitle: Row(
+            children: [
+              Image.asset(
+                itemSite.logo,
+                width: 20,
+              ),
+              AppStyle.hGap4,
+              Text(
+                itemSite.name,
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: Colors.grey,
+                ),
+              ),
+              AppStyle.hGap8,
+              Text(
+                Utils.parseTime(item.updateTime),
+                style: const TextStyle(fontSize: 12, color: Colors.grey),
+              ),
+            ],
+          ),
+          trailing: (rxSite.value.id == item.siteId &&
+                  rxRoomId.value == item.roomId)
+              ? const SizedBox(
+                  width: 64,
+                  child: Center(
+                    child: Icon(Icons.play_arrow),
+                  ),
+                )
+              : null,
+          onTap: () {
+            Get.back();
+            resetRoom(
+              itemSite,
+              item.roomId,
+            );
+          },
+        );
+      },
     );
   }
 

--- a/simple_live_app/lib/modules/live_room/live_room_controller.dart
+++ b/simple_live_app/lib/modules/live_room/live_room_controller.dart
@@ -834,34 +834,7 @@ class LiveRoomController extends PlayerController with WidgetsBindingObserver {
     // 不重置状态,保持上次选择的列表
     Utils.showBottomSheet(
       title: "",
-      child: DefaultTabController(
-        length: 2,
-        initialIndex: showFollowList.value ? 0 : 1,
-        child: Column(
-          children: [
-            TabBar(
-              indicatorSize: TabBarIndicatorSize.tab,
-              labelPadding: EdgeInsets.zero,
-              indicatorWeight: 1.0,
-              onTap: (index) {
-                showFollowList.value = index == 0;
-              },
-              tabs: const [
-                Tab(text: "关注列表"),
-                Tab(text: "观看历史"),
-              ],
-            ),
-            Expanded(
-              child: TabBarView(
-                children: [
-                  _buildFollowListView(),
-                  _buildHistoryListView(),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
+      child: _FollowUserBottomSheet(controller: this),
     );
   }
 
@@ -1157,5 +1130,67 @@ ${error?.stackTrace}''');
     danmakuController = null;
     _liveDurationTimer?.cancel(); // 页面关闭时取消定时器
     super.onClose();
+  }
+}
+
+class _FollowUserBottomSheet extends StatefulWidget {
+  final LiveRoomController controller;
+
+  const _FollowUserBottomSheet({required this.controller});
+
+  @override
+  State<_FollowUserBottomSheet> createState() => _FollowUserBottomSheetState();
+}
+
+class _FollowUserBottomSheetState extends State<_FollowUserBottomSheet>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      length: 2,
+      vsync: this,
+      initialIndex: widget.controller.showFollowList.value ? 0 : 1,
+    );
+    _tabController.addListener(() {
+      if (!_tabController.indexIsChanging) {
+        widget.controller.showFollowList.value = _tabController.index == 0;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TabBar(
+          controller: _tabController,
+          indicatorSize: TabBarIndicatorSize.tab,
+          labelPadding: EdgeInsets.zero,
+          indicatorWeight: 1.0,
+          tabs: const [
+            Tab(text: "关注列表"),
+            Tab(text: "观看历史"),
+          ],
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: [
+              widget.controller._buildFollowListView(),
+              widget.controller._buildHistoryListView(),
+            ],
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/simple_live_app/lib/modules/live_room/player/player_controls.dart
+++ b/simple_live_app/lib/modules/live_room/player/player_controls.dart
@@ -11,9 +11,11 @@ import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/live_room/live_room_controller.dart';
 import 'package:simple_live_app/modules/settings/danmu_settings_page.dart';
+import 'package:simple_live_app/services/db_service.dart';
 import 'package:simple_live_app/services/follow_service.dart';
 import 'package:simple_live_app/widgets/desktop_refresh_button.dart';
 import 'package:simple_live_app/widgets/follow_user_item.dart';
+import 'package:simple_live_app/widgets/net_image.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:simple_live_app/widgets/superchat_card.dart';
 import 'dart:async';
@@ -852,50 +854,142 @@ void showFollowUser(LiveRoomController controller) {
     return;
   }
 
+  // 不重置状态,保持上次选择的列表
   Utils.showRightDialog(
-    title: "关注列表",
+    title: "",
     width: 400,
     useSystem: true,
-    child: Obx(
-      () => Stack(
+    child: DefaultTabController(
+      length: 2,
+      initialIndex: controller.showFollowList.value ? 0 : 1,
+      child: Column(
         children: [
-          RefreshIndicator(
-            onRefresh: FollowService.instance.loadData,
-            child: ListView.builder(
-              itemCount: FollowService.instance.liveList.length,
-              itemBuilder: (_, i) {
-                var item = FollowService.instance.liveList[i];
-                return Obx(
-                  () => FollowUserItem(
-                    item: item,
-                    playing: controller.rxSite.value.id == item.siteId &&
-                        controller.rxRoomId.value == item.roomId,
-                    onTap: () {
-                      Utils.hideRightDialog();
-                      controller.resetRoom(
-                        Sites.allSites[item.siteId]!,
-                        item.roomId,
-                      );
-                    },
-                  ),
-                );
-              },
+          TabBar(
+            indicatorSize: TabBarIndicatorSize.tab,
+            labelPadding: EdgeInsets.zero,
+            indicatorWeight: 1.0,
+            onTap: (index) {
+              controller.showFollowList.value = index == 0;
+            },
+            tabs: const [
+              Tab(text: "关注列表"),
+              Tab(text: "观看历史"),
+            ],
+          ),
+          Expanded(
+            child: TabBarView(
+              children: [
+                _buildFollowListForDialog(controller),
+                _buildHistoryListForDialog(controller),
+              ],
             ),
           ),
-          if (Platform.isLinux || Platform.isWindows || Platform.isMacOS)
-            Positioned(
-              right: 12,
-              bottom: 12,
-              child: Obx(
-                () => DesktopRefreshButton(
-                  refreshing: FollowService.instance.updating.value,
-                  onPressed: FollowService.instance.loadData,
-                ),
-              ),
-            ),
         ],
       ),
     ),
+  );
+}
+
+Widget _buildFollowListForDialog(LiveRoomController controller) {
+  return Obx(
+    () => Stack(
+      children: [
+        RefreshIndicator(
+          onRefresh: FollowService.instance.loadData,
+          child: ListView.builder(
+            itemCount: FollowService.instance.liveList.length,
+            itemBuilder: (_, i) {
+              var item = FollowService.instance.liveList[i];
+              return Obx(
+                () => FollowUserItem(
+                  item: item,
+                  playing: controller.rxSite.value.id == item.siteId &&
+                      controller.rxRoomId.value == item.roomId,
+                  onTap: () {
+                    Utils.hideRightDialog();
+                    controller.resetRoom(
+                      Sites.allSites[item.siteId]!,
+                      item.roomId,
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+        if (Platform.isLinux || Platform.isWindows || Platform.isMacOS)
+          Positioned(
+            right: 12,
+            bottom: 12,
+            child: Obx(
+              () => DesktopRefreshButton(
+                refreshing: FollowService.instance.updating.value,
+                onPressed: FollowService.instance.loadData,
+              ),
+            ),
+          ),
+      ],
+    ),
+  );
+}
+
+Widget _buildHistoryListForDialog(LiveRoomController controller) {
+  var historyList = DBService.instance.getHistores();
+  return ListView.builder(
+    itemCount: historyList.length,
+    itemBuilder: (_, i) {
+      var item = historyList[i];
+      var itemSite = Sites.allSites[item.siteId];
+      if (itemSite == null) return const SizedBox.shrink();
+
+      return ListTile(
+        contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 4),
+        leading: NetImage(
+          item.face,
+          width: 48,
+          height: 48,
+          borderRadius: 24,
+        ),
+        title: Text(item.userName),
+        subtitle: Row(
+          children: [
+            Image.asset(
+              itemSite.logo,
+              width: 20,
+            ),
+            AppStyle.hGap4,
+            Text(
+              itemSite.name,
+              style: const TextStyle(
+                fontSize: 12,
+                color: Colors.grey,
+              ),
+            ),
+            AppStyle.hGap8,
+            Text(
+              Utils.parseTime(item.updateTime),
+              style: const TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+          ],
+        ),
+        trailing: (controller.rxSite.value.id == item.siteId &&
+                controller.rxRoomId.value == item.roomId)
+            ? const SizedBox(
+                width: 64,
+                child: Center(
+                  child: Icon(Icons.play_arrow),
+                ),
+              )
+            : null,
+        onTap: () {
+          Utils.hideRightDialog();
+          controller.resetRoom(
+            itemSite,
+            item.roomId,
+          );
+        },
+      );
+    },
   );
 }
 

--- a/simple_live_app/lib/modules/live_room/player/player_controls.dart
+++ b/simple_live_app/lib/modules/live_room/player/player_controls.dart
@@ -859,35 +859,70 @@ void showFollowUser(LiveRoomController controller) {
     title: "",
     width: 400,
     useSystem: true,
-    child: DefaultTabController(
+    child: _FollowUserDialog(controller: controller),
+  );
+}
+
+class _FollowUserDialog extends StatefulWidget {
+  final LiveRoomController controller;
+
+  const _FollowUserDialog({required this.controller});
+
+  @override
+  State<_FollowUserDialog> createState() => _FollowUserDialogState();
+}
+
+class _FollowUserDialogState extends State<_FollowUserDialog>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
       length: 2,
-      initialIndex: controller.showFollowList.value ? 0 : 1,
-      child: Column(
-        children: [
-          TabBar(
-            indicatorSize: TabBarIndicatorSize.tab,
-            labelPadding: EdgeInsets.zero,
-            indicatorWeight: 1.0,
-            onTap: (index) {
-              controller.showFollowList.value = index == 0;
-            },
-            tabs: const [
-              Tab(text: "关注列表"),
-              Tab(text: "观看历史"),
+      vsync: this,
+      initialIndex: widget.controller.showFollowList.value ? 0 : 1,
+    );
+    _tabController.addListener(() {
+      if (!_tabController.indexIsChanging) {
+        widget.controller.showFollowList.value = _tabController.index == 0;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TabBar(
+          controller: _tabController,
+          indicatorSize: TabBarIndicatorSize.tab,
+          labelPadding: EdgeInsets.zero,
+          indicatorWeight: 1.0,
+          tabs: const [
+            Tab(text: "关注列表"),
+            Tab(text: "观看历史"),
+          ],
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: [
+              _buildFollowListForDialog(widget.controller),
+              _buildHistoryListForDialog(widget.controller),
             ],
           ),
-          Expanded(
-            child: TabBarView(
-              children: [
-                _buildFollowListForDialog(controller),
-                _buildHistoryListForDialog(controller),
-              ],
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
+        ),
+      ],
+    );
+  }
 }
 
 Widget _buildFollowListForDialog(LiveRoomController controller) {


### PR DESCRIPTION
## 功能描述

在播放页面长按屏幕弹出的关注列表弹窗中，添加了"关注列表"和"观看历史"的切换功能。

## 主要改动

### 1. 添加切换功能
- 使用 `TabBar` + `TabBarView` 实现列表切换
- 支持在"关注列表"和"观看历史"之间切换
- UI 风格与项目现有的 Tab 样式保持一致

### 2. 状态记忆
- 记住用户上次选择的列表类型
- 下次打开时自动显示上次选择的列表

### 3. 观看历史功能
- 复用现有的观看历史数据
- 显示主播头像、名称、平台 logo、观看时间
- 点击历史记录可以跳转到对应的直播间
- 正在观看的直播间显示播放图标标识

## 修改的文件

- `simple_live_app/lib/modules/live_room/live_room_controller.dart`
  - 添加 `showFollowList` 状态变量
  - 重构 `showFollowUserSheet()` 方法
  - 新增 `_buildFollowListView()` 和 `_buildHistoryListView()` 辅助方法

- `simple_live_app/lib/modules/live_room/player/player_controls.dart`
  - 重构 `showFollowUser()` 函数
  - 新增 `_buildFollowListForDialog()` 和 `_buildHistoryListForDialog()` 辅助函数
  - 添加必要的 imports

## 截图/演示

用户长按播放页面屏幕时，会弹出一个带有 Tab 切换的弹窗：
- 顶部有"关注列表"和"观看历史"两个 Tab
- 可以点击 Tab 或滑动切换
- 下次打开时会记住上次选择的 Tab

## 测试

- [x] macOS debug 版本构建成功
- [x] 切换功能正常工作
- [x] 状态记忆功能正常
- [x] 观看历史列表显示正常
- [x] 点击跳转功能正常

## 相关 Issue

无