### PR TITLE
fix(ios): 修复返回前台后弹幕不再显示

### DIFF
--- a/simple_live_app/lib/modules/live_room/live_room_controller.dart
+++ b/simple_live_app/lib/modules/live_room/live_room_controller.dart
@@ -1009,7 +1009,8 @@ ${error?.stackTrace}''');
 
     if (state == AppLifecycleState.paused) {
       Log.d("进入后台");
-      //进入后台，关闭弹幕
+      // 进入后台，暂停并清空弹幕。
+      danmakuController?.pause();
       danmakuController?.clear();
       isBackground = true;
     } else
@@ -1017,6 +1018,9 @@ ${error?.stackTrace}''');
     if (state == AppLifecycleState.resumed) {
       Log.d("返回前台");
       isBackground = false;
+      // canvas_danmaku 会在应用进入后台时暂停，但不会自行恢复。
+      // 直播流刷新不会重建弹幕视图，因此需要在这里显式恢复动画。
+      danmakuController?.resume();
     }
   }
 

--- a/simple_live_app/test/modules/live_room/live_room_controller_test.dart
+++ b/simple_live_app/test/modules/live_room/live_room_controller_test.dart
@@ -1,0 +1,46 @@
+import 'package:canvas_danmaku/canvas_danmaku.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:simple_live_app/app/sites.dart';
+import 'package:simple_live_app/modules/live_room/live_room_controller.dart';
+import 'package:simple_live_core/simple_live_core.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('resumes danmaku after returning from the background', () {
+    final controller = LiveRoomController(
+      pSite: Site(
+        id: 'test',
+        name: 'Test',
+        logo: '',
+        liveSite: LiveSite(),
+      ),
+      pRoomId: '1',
+    );
+    var pauseCount = 0;
+    var clearCount = 0;
+    var resumeCount = 0;
+
+    controller.initDanmakuController(
+      DanmakuController(
+        onAddDanmaku: (_) {},
+        onUpdateOption: (_) {},
+        onPause: () => pauseCount++,
+        onResume: () => resumeCount++,
+        onClear: () => clearCount++,
+      ),
+    );
+
+    controller.didChangeAppLifecycleState(AppLifecycleState.paused);
+
+    expect(controller.isBackground, isTrue);
+    expect(pauseCount, 1);
+    expect(clearCount, 1);
+
+    controller.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+    expect(controller.isBackground, isFalse);
+    expect(resumeCount, 1);
+  });
+}


### PR DESCRIPTION
## Background\n\n在 iOS 上，应用进入后台后再返回直播间，所有弹幕会持续消失；重新加载直播流无效，只有退出直播间重进才能恢复。\n\n原因是 canvas_danmaku 0.2.7 会在 AppLifecycleState.paused 时暂停 DanmakuScreen，但不会在 AppLifecycleState.resumed 时自行恢复。暂停后，其内部运行状态保持为 false，后续弹幕会被直接丢弃。直播流刷新会复用缓存的弹幕视图，因此无法恢复渲染。\n\n## Summary\n\n- 应用进入后台时显式暂停并清空弹幕。\n- 应用返回前台时显式恢复弹幕控制器。\n- 新增生命周期回归测试，覆盖 paused 到 resumed 的状态变化。\n\n## Tests\n\n- flutter test test/modules/live_room/live_room_controller_test.dart\n- flutter analyze